### PR TITLE
Add Waybar-style top bar above profile page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,14 @@
 import Profile from '../components/Profile';
+import TopBar from '../components/TopBar';
+import Clock from '../components/Clock';
 
 export default function Home() {
   return (
-    <main className="min-h-screen flex items-center justify-center">
-      <Profile />
-    </main>
+    <>
+      <TopBar left={<span>D-Angelo</span>} center={<span>Profile</span>} right={<Clock />} />
+      <main className="min-h-screen flex items-center justify-center">
+        <Profile />
+      </main>
+    </>
   );
 }

--- a/src/components/Clock.tsx
+++ b/src/components/Clock.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { useState, useEffect } from 'react';
+
+const Clock = () => {
+  const [time, setTime] = useState(new Date());
+
+  useEffect(() => {
+    const interval = setInterval(() => setTime(new Date()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return <span>{time.toLocaleTimeString()}</span>;
+};
+
+export default Clock;

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,0 +1,20 @@
+'use client'
+import React from 'react';
+
+interface TopBarProps {
+  left?: React.ReactNode;
+  center?: React.ReactNode;
+  right?: React.ReactNode;
+}
+
+const TopBar = ({ left, center, right }: TopBarProps) => {
+  return (
+    <div className="w-full h-12 bg-gray-800 text-white flex items-center px-4">
+      <div className="flex-1 flex items-center">{left}</div>
+      <div className="flex-1 text-center">{center}</div>
+      <div className="flex-1 flex justify-end items-center">{right}</div>
+    </div>
+  );
+};
+
+export default TopBar;


### PR DESCRIPTION
## Summary
- add `Clock` component for time display
- add `TopBar` component with configurable sections
- display the new bar in the profile page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853bec308408329a64c87663b2a5ad2